### PR TITLE
Limit BMR and TDEE history values to 2 decimal places

### DIFF
--- a/app/src/main/java/in/iot/lab/healthyways/adapters/BMRHistoryAdapter.kt
+++ b/app/src/main/java/in/iot/lab/healthyways/adapters/BMRHistoryAdapter.kt
@@ -13,6 +13,7 @@ import androidx.annotation.RequiresApi
 import androidx.recyclerview.widget.RecyclerView
 
 import kotlinx.android.synthetic.main.bmr_history_item.view.*
+import java.text.DecimalFormat
 import java.util.*
 
 class BMRHistoryAdapter(private val context: Context, private val listener: IBMRHistoryRVAdapter):
@@ -47,8 +48,13 @@ class BMRHistoryAdapter(private val context: Context, private val listener: IBMR
         holder.exerExtent.text = currentHistory.exerExtent
         holder.weightValue.text = currentHistory.weightValue
         holder.heightValue.text = currentHistory.heightValue
-        holder.bmrValue.text = currentHistory.bmrValue
-        holder.tdeeValue.text = currentHistory.tdeeValue
+        val formatter = DecimalFormat("#.##")
+        currentHistory.bmrValue.toDoubleOrNull()?.let {
+            holder.bmrValue.text = formatter.format(it)
+        }
+        currentHistory.tdeeValue.toDoubleOrNull()?.let {
+            holder.tdeeValue.text = formatter.format(it)
+        }
         holder.bmrDateT.text = currentHistory.bmrDateT
 
     }


### PR DESCRIPTION
Fix for issue #1

Limit the BMR and TDEE values in the BMR history cards to a maximum of 2 decimal places. This is done using DecimalFormat("#.##") in the BMRHistoryAdapter before the values are set in the TextViews.

Before after after:

<img src="https://user-images.githubusercontent.com/91746301/136239774-291b1cbf-6f74-460d-9825-c0d1c24fa434.png" width="50%"><img src="https://user-images.githubusercontent.com/91746301/136239781-5f80422d-5673-47e6-bb12-3e75e1ff70bc.png" width="50%">